### PR TITLE
Refactorize asyncStorage

### DIFF
--- a/src/helpers/functions/asyncStorage.ts
+++ b/src/helpers/functions/asyncStorage.ts
@@ -36,9 +36,12 @@ export const ArrayStorage = {
   // (key를 통해 찾은 배열) 에서 value를 찾아 삭제하여 저장
   removeElem: (key: string, value: string | Record<string, unknown>): void => {
     AsyncStorage.getItem(key).then((res) => {
-      let parsedValue = res !== null ? JSON.parse(res) : null;
-      parsedValue = parsedValue.filter((item: string) => item !== value);
-      AsyncStorage.setItem(key, JSON.stringify(parsedValue));
+      const parsedValue = res !== null ? JSON.parse(res) : null;
+      const targetInd = parsedValue.indexOf(value);
+      const filteredValue = parsedValue.filter(
+        (_: any, ind: number) => ind !== targetInd
+      );
+      AsyncStorage.setItem(key, JSON.stringify(filteredValue));
     });
   },
 };

--- a/src/helpers/hooks/useKeywordDispatch.ts
+++ b/src/helpers/hooks/useKeywordDispatch.ts
@@ -1,7 +1,7 @@
 import { useDispatch } from 'react-redux';
 
 import { asyncStoragekey } from '@/constants/asyncStorage';
-import * as asyncStorageFunc from '@/helpers/functions/asyncStorage';
+import { ArrayStorage } from '@/helpers/functions/asyncStorage';
 import { setKeyword, addRecentSearch } from '@/store/searchSlice';
 
 type TUseKeywordDispath = () => (keyword: string) => void;
@@ -11,7 +11,7 @@ const useKeywordDispatch: TUseKeywordDispath = () => {
   return (keyword: string) => {
     dispatch(addRecentSearch({ keyword }));
     dispatch(setKeyword({ keyword }));
-    asyncStorageFunc.addPropArrElem(asyncStoragekey.RECENT_SEARCH, keyword);
+    ArrayStorage.addElem(asyncStoragekey.RECENT_SEARCH, keyword);
   };
 };
 

--- a/src/screens/Search/SearchSection/RecentSearch/index.tsx
+++ b/src/screens/Search/SearchSection/RecentSearch/index.tsx
@@ -6,7 +6,7 @@ import { Icon } from 'native-base';
 
 import Tag from '@/components/Button';
 import { useKeywordDispatch } from '@/helpers/hooks';
-import * as asyncStorageFunc from '@/helpers/functions/asyncStorage';
+import { ArrayStorage } from '@/helpers/functions/asyncStorage';
 import { asyncStoragekey } from '@/constants/asyncStorage';
 import { removeKeyword } from '@/store/searchSlice';
 
@@ -24,7 +24,7 @@ function RecentSearch({ tags }: IRecentSearchProps): JSX.Element {
 
   // x 누르면 asyncstorage와 recentSearchStorage 갱신
   const onPressXIcon = useCallback((tag: string) => {
-    asyncStorageFunc.removePropArrElem(asyncStoragekey.RECENT_SEARCH, tag);
+    ArrayStorage.removeElem(asyncStoragekey.RECENT_SEARCH, tag);
     dispatch(removeKeyword({ keyword: tag }));
   }, []);
 


### PR DESCRIPTION
전체적으로, 우리 api 다뤘던 것처럼 바꿔야 할 것 같습니다.

api 파일을 거치지 않고서는 서버와 소통할 수 없듯이 asyncStorage를 통하지 않고서는 storage와 소통할 수 없게 이 파일을 통해서 abstraction이 한 채널 생기는 게 좋을 것 같아요

그런 의미에서 의도대로 함수들이 작동하는지 확인 부탁드리고, 함수 이름이 바뀌었으니 @ssu1018 님께서 바뀐 상황에 맞게 원래 이 함수들 사용하던 코드 수정해서 이 브랜치로 PR해 주시면 좋을 것 같습니다

그런 의미에서 처음에 배열 저장하는 것도 이 파일 통해 처리하는 게 좋지 않을까 싶은데 어떠신가요?