### PR TITLE
로그인 로직 변경 대응

### DIFF
--- a/src/apis/UserApi.ts
+++ b/src/apis/UserApi.ts
@@ -9,7 +9,7 @@ export const readMyInfo = (): Promise<AxiosResponse<IUserProps>> => {
 };
 
 export const logout = (): Promise<AxiosResponse<any>> => {
-  return requester.put('user/logout/', {});
+  return requester.put('user/logout/');
 };
 
 export const login = (

--- a/src/apis/UserApi.ts
+++ b/src/apis/UserApi.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse } from 'axios';
+import { AxiosResponse } from 'axios';
 
 import { IUserProps } from '@/types/user';
 

--- a/src/apis/UserApi.ts
+++ b/src/apis/UserApi.ts
@@ -1,4 +1,4 @@
-import { AxiosResponse } from 'axios';
+import axios, { AxiosResponse } from 'axios';
 
 import { IUserProps } from '@/types/user';
 

--- a/src/screens/SignUp/index.tsx
+++ b/src/screens/SignUp/index.tsx
@@ -187,8 +187,8 @@ function SignUpTemplate(): JSX.Element {
         dispatch(login(id, pw, navigation));
       })
       .catch((err: AxiosError) => {
-        console.error(err);
-        switch (parseInt(err.code + '')) {
+        console.error(err.config);
+        switch (err.response?.status) {
           case 400:
             Alert.alert(err.message);
             break;

--- a/src/store/userSlice/index.ts
+++ b/src/store/userSlice/index.ts
@@ -76,10 +76,13 @@ export const login = (
         // 서버에서 2xx 가 아닌 response를 내려줌
         switch (error.response.status) {
           case 401:
+            // wrong id / pw
             Alert.alert(get(error, ['response', 'data', 'error']));
             break;
           case 403:
+            // csrf error
             Alert.alert(get(error, ['response', 'data', 'detail']));
+            dispatch(logout());
             break;
           default:
             // 예상치 못한 에러 코드
@@ -98,9 +101,18 @@ export const login = (
 };
 
 export const logout = (): AppThunk => (dispatch) => {
-  removeToken();
-  ObjectStorage.removeObject(asyncStoragekey.USER);
-  dispatch(clearInfo());
+  userAPI
+    .logout()
+    .then(() => {
+      removeToken();
+      ObjectStorage.removeObject(asyncStoragekey.USER);
+      dispatch(clearInfo());
+    })
+    .catch((error: AxiosError) => {
+      console.debug(error.config);
+      console.debug(error.response?.data);
+      console.debug(error.response?.status);
+    });
 };
 
 export const modify = (

--- a/src/store/userSlice/index.ts
+++ b/src/store/userSlice/index.ts
@@ -1,6 +1,6 @@
 import { Alert } from 'react-native';
 
-import axios, { AxiosError } from 'axios';
+import { AxiosError } from 'axios';
 
 import { NavigationProp } from '@react-navigation/native';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
@@ -11,7 +11,6 @@ import { asyncStoragekey } from '@/constants/asyncStorage';
 import { ObjectStorage } from '@/helpers/functions/asyncStorage';
 import { AppThunk } from '@/store';
 import { IUserProps } from '@/types/user';
-import { err } from 'react-native-svg/lib/typescript/xml';
 import get from 'lodash/get';
 
 const initialState = {
@@ -74,6 +73,7 @@ export const login = (
     })
     .catch((error: AxiosError) => {
       if (error.response) {
+        // 서버에서 2xx 가 아닌 response를 내려줌
         switch (error.response.status) {
           case 401:
             Alert.alert(get(error, ['response', 'data', 'error']));
@@ -87,6 +87,12 @@ export const login = (
               '예상치 못한 에러가 발생했습니다. 고객센터로 문의해주시기 바랍니다.'
             );
         }
+      } else if (error.request) {
+        // 서버에서 response 자체가 안 옴
+        Alert.alert('서버와 연결할 수 없습니다.');
+      } else {
+        // 뭔지 모를 때 디버깅 용도
+        console.debug(error.config);
       }
     });
 };

--- a/src/store/userSlice/index.ts
+++ b/src/store/userSlice/index.ts
@@ -1,6 +1,6 @@
 import { Alert } from 'react-native';
 
-import { AxiosError } from 'axios';
+import axios, { AxiosError } from 'axios';
 
 import { NavigationProp } from '@react-navigation/native';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
@@ -11,6 +11,8 @@ import { asyncStoragekey } from '@/constants/asyncStorage';
 import { ObjectStorage } from '@/helpers/functions/asyncStorage';
 import { AppThunk } from '@/store';
 import { IUserProps } from '@/types/user';
+import { err } from 'react-native-svg/lib/typescript/xml';
+import get from 'lodash/get';
 
 const initialState = {
   info: {
@@ -70,13 +72,21 @@ export const login = (
       dispatch(setInfo(response.data));
       navigation.navigate('Home');
     })
-    .catch((err: AxiosError) => {
-      switch (parseInt(err.code + '')) {
-        case 403:
-          Alert.alert(err.message);
-          break;
-        default:
-          Alert.alert('unknown error');
+    .catch((error: AxiosError) => {
+      if (error.response) {
+        switch (error.response.status) {
+          case 401:
+            Alert.alert(get(error, ['response', 'data', 'error']));
+            break;
+          case 403:
+            Alert.alert(get(error, ['response', 'data', 'detail']));
+            break;
+          default:
+            // 예상치 못한 에러 코드
+            Alert.alert(
+              '예상치 못한 에러가 발생했습니다. 고객센터로 문의해주시기 바랍니다.'
+            );
+        }
       }
     });
 };


### PR DESCRIPTION
Alert.alert 함수 내부에서 모종의 이유로 에러가 날 경우 앱이 튕기는 현상이 확인되어 안정성을 위해 lodash.get을 사용하였습니다.

error code handling하는 로직이 상당히 복잡하여 유틸 함수로 하나 빼놓으면 좋을 것 같은데 의견 부탁드립니다.